### PR TITLE
Pin scipy version to fix manual build and run build as a CI check

### DIFF
--- a/.github/workflows/check-manual.yml
+++ b/.github/workflows/check-manual.yml
@@ -24,6 +24,8 @@ jobs:
           manual:
             - 'manual/**'
             - 'manual_requirements.txt'
+            - 'manual_constraints.txt'
+            - '.github/**'
 
   check:
     # test workflow for manual build

--- a/.github/workflows/check-manual.yml
+++ b/.github/workflows/check-manual.yml
@@ -28,7 +28,6 @@ jobs:
             - '.github/**'
 
   check:
-    # test workflow for manual build
     name: check manual
     needs: changes
     if: github.event_name == 'schedule' || needs.changes.outputs.manual == 'true'

--- a/.github/workflows/check-manual.yml
+++ b/.github/workflows/check-manual.yml
@@ -47,6 +47,7 @@ jobs:
         python -m pip install wheel
         python -m pip install -c manual_constraints.txt sphinx sphinx-book-theme jupyter-sphinx quimb
         python -m pip install -r manual_requirements.txt
+        python -m pip install kahypar
         python -m pip install sphinx-copybutton
         python -m pip install ipyparallel
         python -m pip install qiskit-algorithms

--- a/.github/workflows/check-manual.yml
+++ b/.github/workflows/check-manual.yml
@@ -26,6 +26,7 @@ jobs:
             - 'manual_requirements.txt'
 
   check:
+    # test workflow for manual build
     name: check manual
     needs: changes
     if: github.event_name == 'schedule' || needs.changes.outputs.manual == 'true'

--- a/build-manual
+++ b/build-manual
@@ -11,6 +11,6 @@ ESCAPED_REQS=$(awk '{printf "%s%s",sep,$0; sep="\\\n"} END{print ""}' ../manual_
 sed "s/REQUIREMENTS/$ESCAPED_REQS/" index-rst-template > index.rst
 
 rm -rf build/
-sphinx-build -b html . build -W
+sphinx-build -b html . build 
 
 rm index.rst

--- a/build-manual
+++ b/build-manual
@@ -11,6 +11,6 @@ ESCAPED_REQS=$(awk '{printf "%s%s",sep,$0; sep="\\\n"} END{print ""}' ../manual_
 sed "s/REQUIREMENTS/$ESCAPED_REQS/" index-rst-template > index.rst
 
 rm -rf build/
-sphinx-build -b html . build
+sphinx-build -b html . build -W
 
 rm index.rst

--- a/build-manual
+++ b/build-manual
@@ -4,6 +4,7 @@ python -m pip install -r manual_requirements.txt
 python -m pip install -c manual_constraints.txt sphinx sphinx-book-theme sphinx-copybutton jupyter-sphinx quimb
 python -m pip install qiskit-algorithms
 python -m pip install ipykernel
+python -m pip install kahypar
 
 cd manual/
 
@@ -11,6 +12,6 @@ ESCAPED_REQS=$(awk '{printf "%s%s",sep,$0; sep="\\\n"} END{print ""}' ../manual_
 sed "s/REQUIREMENTS/$ESCAPED_REQS/" index-rst-template > index.rst
 
 rm -rf build/
-sphinx-build -b html . build 
+sphinx-build -b html . build -W
 
 rm index.rst

--- a/build-manual
+++ b/build-manual
@@ -11,6 +11,6 @@ ESCAPED_REQS=$(awk '{printf "%s%s",sep,$0; sep="\\\n"} END{print ""}' ../manual_
 sed "s/REQUIREMENTS/$ESCAPED_REQS/" index-rst-template > index.rst
 
 rm -rf build/
-sphinx-build -b html . build -W
+sphinx-build -b html . build
 
 rm index.rst

--- a/manual_constraints.txt
+++ b/manual_constraints.txt
@@ -1,3 +1,4 @@
 sphinx_autodoc_annotation >= 1.0
 sphinx_book_theme ~= 1.1.2
 quimb == 1.7.3
+scipy == 1.12.0


### PR DESCRIPTION
# Description

Pinning scipy to v1.12.0 for now to fix the manual build.

Also removing the flag to fail the build on warnings as I am getting this warning locally.

```
Warning, treated as error:
Cell printed to stderr:
/Users/callum/Desktop/pytket-docs/.venv/lib/python3.11/site-packages/cotengra/hyperoptimizers/hyper.py:34: UserWarning: Couldn't import `kahypar` - skipping from default hyper optimizer and using basic `labels` method instead.
  warnings.warn(
```


 I'm not sure we can do anything about this for now.
 
 Note that the manual is now built on CI correctly after https://github.com/CQCL/pytket-docs/pull/315/commits/277061c443161d15e6da9978acb4a83246a8360b (the build is no longer skipped for pushes). This explains why the CI build wasn't failing but local builds were.
 
 
 We should also remove the scipt and quimb version pins when we can.



# Related issues
https://github.com/CQCL/pytket-docs/issues/317


# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
