### PR TITLE
Add flag to fail manual CI build on warnings 

### DIFF
--- a/.github/workflows/check-manual.yml
+++ b/.github/workflows/check-manual.yml
@@ -60,4 +60,3 @@ jobs:
         cd manual/
         sed "s/REQUIREMENTS/$(sed -e 's/[\&/]/\\&/g' -e 's/$/\\n/' ../manual_requirements.txt | tr -d '\n')/" index-rst-template > index.rst
         sphinx-build -b html . build -W
-

--- a/.github/workflows/check-manual.yml
+++ b/.github/workflows/check-manual.yml
@@ -59,4 +59,4 @@ jobs:
       run: |
         cd manual/
         sed "s/REQUIREMENTS/$(sed -e 's/[\&/]/\\&/g' -e 's/$/\\n/' ../manual_requirements.txt | tr -d '\n')/" index-rst-template > index.rst
-        sphinx-build -b html . build
+        sphinx-build -b html . build -W


### PR DESCRIPTION
# Description

Adding a flag to fail the manual build on warnings. This is consistent wiht the tket website build and the local `./build-manual` script.

Ensures that warnings from the local build are caught by the CI checks.

# Related issues

Please mention any github issues addressed by this PR.

# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
