### PR TITLE
Fix spacing in multiplexor table

### DIFF
--- a/manual/manual_circuit.rst
+++ b/manual/manual_circuit.rst
@@ -975,13 +975,13 @@ Multiplexor                                             Description
 :py:class:`~pytket.circuit.MultiplexorBox`              The most general type of multiplexor (see above)
                                
 :py:class:`~pytket.circuit.MultiplexedRotationBox`      Multiplexor where the operation applied to the 
-                                                          target is a rotation gate about a single axis
+                                                        target is a rotation gate about a single axis
                                         
 :py:class:`~pytket.circuit.MultiplexedU2Box`            Multiplexor for unifromly controlled single
                                                         qubit gates (U(2) operations)
 
 :py:class:`~pytket.circuit.MultiplexedTensoredU2Box`    Multiplexor where the operation applied to the
-                                                         target is a tensor product of single qubit gates
+                                                        target is a tensor product of single qubit gates
                                                                        
 ====================================================    =====================================================
 

--- a/manual/manual_circuit.rst
+++ b/manual/manual_circuit.rst
@@ -977,8 +977,8 @@ Multiplexor                                             Description
 :py:class:`~pytket.circuit.MultiplexedRotationBox`      Multiplexor where the operation applied to the 
                                                         target is a rotation gate about a single axis
                                         
-:py:class:`~pytket.circuit.MultiplexedU2Box`            Multiplexor for unifromly controlled single
-                                                        qubit gates (U(2) operations)
+:py:class:`~pytket.circuit.MultiplexedU2Box`            Multiplexor for uniformly controlled single
+                                                        qubit gates (:math:`U(2)` operations)
 
 :py:class:`~pytket.circuit.MultiplexedTensoredU2Box`    Multiplexor where the operation applied to the
                                                         target is a tensor product of single qubit gates

--- a/manual/manual_circuit.rst
+++ b/manual/manual_circuit.rst
@@ -972,16 +972,16 @@ In addition to the general :py:class:`~pytket.circuit.Multiplexor` pytket has se
 ====================================================    =====================================================
 Multiplexor                                             Description
 ====================================================    =====================================================
-:py:class:`~pytket.circuit.MultiplexorBox`              The most general type of multiplexor (see above)
+:py:class:`~pytket.circuit.MultiplexorBox`              The most general type of multiplexor (see above).
                                
 :py:class:`~pytket.circuit.MultiplexedRotationBox`      Multiplexor where the operation applied to the 
-                                                        target is a rotation gate about a single axis
+                                                        target is a rotation gate about a single axis.
                                         
 :py:class:`~pytket.circuit.MultiplexedU2Box`            Multiplexor for uniformly controlled single
-                                                        qubit gates (:math:`U(2)` operations)
+                                                        qubit gates ( :math:`U(2)` operations).
 
 :py:class:`~pytket.circuit.MultiplexedTensoredU2Box`    Multiplexor where the operation applied to the
-                                                        target is a tensor product of single qubit gates
+                                                        target is a tensor product of single qubit gates.
                                                                        
 ====================================================    =====================================================
 

--- a/manual/manual_circuit.rst
+++ b/manual/manual_circuit.rst
@@ -967,7 +967,7 @@ Notice how in the example above the control qubits are both in the :math:`|1\ran
     # Amplitudes of |+> approx 0.707...
     print("Statevector =", np.round(multi_circ.get_statevector().real, 4))
 
-In addition to the general :py:class:`~pytket.circuit.Multiplexor` pytket has several other type of multiplexor box operations available.
+In addition to the general :py:class:`~pytket.circuit.MultiplexorBox` pytket has several other type of multiplexor box operations available.
 
 ====================================================    =====================================================
 Multiplexor                                             Description


### PR DESCRIPTION
# Description

The spacing in the multiplexor table was messed up. It looks particularly bad in dark mode. Probably due to a change in #309.

Also fixed a typo and made some minor formatting fixes.

Before 

<img width="819" alt="Screenshot 2024-04-25 at 18 50 42" src="https://github.com/CQCL/pytket-docs/assets/93673602/2a282a9e-10ff-4f92-ab6a-4108a40374c7">


After (local build)

<img width="798" alt="Screenshot 2024-04-25 at 18 57 01" src="https://github.com/CQCL/pytket-docs/assets/93673602/e82f0d21-9642-4ac3-90f6-b98703e8574c">


# Related issues

Please mention any github issues addressed by this PR.

# Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
