### PR TITLE
fix: update faulty manual example on `AerBackend` compilation

### DIFF
--- a/manual/manual_backend.rst
+++ b/manual/manual_backend.rst
@@ -62,10 +62,9 @@ Knowing the requirements of each :py:class:`~pytket.backends.Backend` is handy i
     circ.measure_all()
 
     backend = AerBackend()
-    if not backend.valid_circuit(circ):
-        compiled_circ = backend.get_compiled_circuit(circ) # Compile circuit to AerBackend
+    compiled_circ = backend.get_compiled_circuit(circ) # Compile circuit to AerBackend
 
-    print("Valid circuit for AerBackend?", backend.valid_circuit(compiled_circ))
+    print("Compiled circuit valid for AerBackend?", backend.valid_circuit(compiled_circ))
 
 Now that we can prepare our :py:class:`~pytket.circuit.Circuit` s to be suitable for a given :py:class:`~pytket.backends.Backend`, we can send them off to be run and examine the results. This is always done by calling :py:meth:`~pytket.backends.Backend.process_circuit()` which sends a :py:class:`~pytket.circuit.Circuit` for execution and returns a :py:class:`~pytket.backends.resulthandle.ResultHandle` as an identifier for the job which can later be used to retrieve the actual results once the job has finished.
 

--- a/manual/manual_backend.rst
+++ b/manual/manual_backend.rst
@@ -62,6 +62,7 @@ Knowing the requirements of each :py:class:`~pytket.backends.Backend` is handy i
     circ.measure_all()
 
     backend = AerBackend()
+    print("Circuit valid for AerBackend?", backend.valid_circuit(circ))
     compiled_circ = backend.get_compiled_circuit(circ) # Compile circuit to AerBackend
 
     print("Compiled circuit valid for AerBackend?", backend.valid_circuit(compiled_circ))

--- a/manual/manual_backend.rst
+++ b/manual/manual_backend.rst
@@ -53,18 +53,19 @@ Knowing the requirements of each :py:class:`~pytket.backends.Backend` is handy i
 
 .. jupyter-execute::
 
-    from pytket import Circuit
+    from pytket import Circuit, OpType
     from pytket.extensions.qiskit import AerBackend
 
-    circ = Circuit(2, 2)
-    circ.Rx(0.3, 0).Ry(0.5, 1).CRz(-0.6, 1, 0).measure_all()
+    circ = Circuit(3, 2)
+    circ.H(0).Ry(0.25, 1)
+    circ.add_gate(OpType.CnRy, [0.74], [0, 1, 2]) # CnRy not in AerBackend gate set
+    circ.measure_all()
 
     backend = AerBackend()
     if not backend.valid_circuit(circ):
-        compiled_circ = backend.get_compiled_circuit(circ)
-        assert backend.valid_circuit(compiled_circ)
+        compiled_circ = backend.get_compiled_circuit(circ) # Compile circuit to AerBackend
 
-    print(compiled_circ.get_commands())
+    print("Valid circuit for AerBackend?", backend.valid_circuit(compiled_circ))
 
 Now that we can prepare our :py:class:`~pytket.circuit.Circuit` s to be suitable for a given :py:class:`~pytket.backends.Backend`, we can send them off to be run and examine the results. This is always done by calling :py:meth:`~pytket.backends.Backend.process_circuit()` which sends a :py:class:`~pytket.circuit.Circuit` for execution and returns a :py:class:`~pytket.backends.resulthandle.ResultHandle` as an identifier for the job which can later be used to retrieve the actual results once the job has finished.
 


### PR DESCRIPTION
# Description

This example snippet was erroring out causing the manual build to fail. Seems the circuit was always valid for `AerBackend` and so the `compiled_circ` variable was unreachable. Not sure what changed here to explain this.

In any case I've updated the snippet so that the original circuit has a CnRy gate which needs to be compiled down for the circuit to be valid for `AerBackend`.



# Related issues

Please mention any github issues addressed by this PR.

# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
