### PR TITLE
infra: Extend jupyterbook build timeount

### DIFF
--- a/examples/_config.yml
+++ b/examples/_config.yml
@@ -13,8 +13,8 @@ sphinx:
 
 execute:
   # Exclude some examples from execution (these are still deployed as html pages)
-  exclude_patterns: [".venv/*", "Forest_portability_example.ipynb", "backends_example.ipynb", "qiskit_integration.ipynb", "comparing_simulators.ipynb", "expectation_value_example.ipynb", "pytket-qujax_heisenberg_vqe.ipynb", "spam_example.ipynb", "entanglement_swapping.ipynb", "pytket-qujax-classification.ipynb"]
-  timeout: 90    # The maximum time (in seconds) each notebook cell is allowed to run.
+  exclude_patterns: [".venv/*", "Forest_portability_example.ipynb", "backends_example.ipynb", "qiskit_integration.ipynb", "comparing_simulators.ipynb", "expectation_value_example.ipynb", "pytket-qujax_heisenberg_vqe.ipynb", "spam_example.ipynb", "entanglement_swapping.ipynb", "pytket-qujax-classification.ipynb", "ucc_vqe.ipynb"]
+  timeout: 120    # The maximum time (in seconds) each notebook cell is allowed to run.
 
 # Information about where the book exists on the web
 repository:

--- a/examples/_config.yml
+++ b/examples/_config.yml
@@ -13,7 +13,7 @@ sphinx:
 
 execute:
   # Exclude some examples from execution (these are still deployed as html pages)
-  exclude_patterns: [".venv/*", "Forest_portability_example.ipynb", "backends_example.ipynb", "qiskit_integration.ipynb", "comparing_simulators.ipynb", "expectation_value_example.ipynb", "pytket-qujax_heisenberg_vqe.ipynb", "spam_example.ipynb", "entanglement_swapping.ipynb", "pytket-qujax-classification.ipynb", "ucc_vqe.ipynb"]
+  exclude_patterns: [".venv/*", "Forest_portability_example.ipynb", "backends_example.ipynb", "qiskit_integration.ipynb", "comparing_simulators.ipynb", "expectation_value_example.ipynb", "pytket-qujax_heisenberg_vqe.ipynb", "spam_example.ipynb", "entanglement_swapping.ipynb", "pytket-qujax-classification.ipynb"]
   timeout: 120    # The maximum time (in seconds) each notebook cell is allowed to run.
 
 # Information about where the book exists on the web


### PR DESCRIPTION
# Description

Extending the jupyterbook timeout to 120s as some of the examples are very close to the 90s per cell limit. This was  issues with the website build. The build was erroring out on certain runs. 

I think the ucc_vqe example and possibly the pytket-qujax qaoa examples are the offenders.
