### PR TITLE
update pytket versions to 1.31

### DIFF
--- a/examples/example_requirements.txt
+++ b/examples/example_requirements.txt
@@ -1,4 +1,4 @@
-pytket == 1.27.0
+pytket == 1.31.0
 pytket-cirq == 0.36.0
 pytket-qiskit == 0.53.0
 pytket-qujax == 0.19.0

--- a/manual_requirements.txt
+++ b/manual_requirements.txt
@@ -1,3 +1,3 @@
-    pytket[ZX] == 1.27.0
+    pytket[ZX] == 1.31.0
     pytket-qiskit == 0.53.0
     pytket-cirq == 0.36.0


### PR DESCRIPTION
Website build is failing as the dependencies are hardcoded in this repository.

Dependencies are reorganised in #339 