### PR TITLE
docs: Replace deprecated uses of `auto_rebase_pass` and `auto_squash_pass`

### DIFF
--- a/docs/manual/manual_compiler.rst
+++ b/docs/manual/manual_compiler.rst
@@ -142,17 +142,17 @@ One of the simplest constraints to solve for is the :py:class:`~pytket.predicate
 
     print(circ.get_commands())
 
-For some gatesets, it is not even necessary to specify the CX and TK1 decompositions: there is a useful function :py:meth:`auto_rebase_pass` which can take care of this for you. The pass returned is constructed from the gateset alone. (It relies on some known decompositions, and will raise an exception if no suitable known decompositions exist.) An example is given in the "Combinators" section below.
+For some gatesets, it is not even necessary to specify the CX and TK1 decompositions: there is a useful function :py:meth:`AutoRebase` which can take care of this for you. The pass returned is constructed from the gateset alone. (It relies on some known decompositions, and will raise an exception if no suitable known decompositions exist.) An example is given in the "Combinators" section below.
 
-A similar pair of methods, :py:meth:`SquashCustom` and :py:meth:`auto_squash_pass`, may be used to construct a pass that squashes sequences of single-qubit gates from a given set of single-qubit gates to as short a sequence as possible. Both take a gateset as an argument. :py:meth:`SquashCustom` also takes a function for converting the parameters of a TK1 gate to the target gate set. (Internally, the compiler squashes all gates to TK1 and then applies the supplied function.) :py:meth:`auto_squash_pass` attempts to do the squash using known internal decompositions (but may fail for some gatesets). For example:
+A similar pair of methods, :py:meth:`SquashCustom` and :py:meth:`AutoSquash`, may be used to construct a pass that squashes sequences of single-qubit gates from a given set of single-qubit gates to as short a sequence as possible. Both take a gateset as an argument. :py:meth:`SquashCustom` also takes a function for converting the parameters of a TK1 gate to the target gate set. (Internally, the compiler squashes all gates to TK1 and then applies the supplied function.) :py:meth:`AutoSquash` attempts to do the squash using known internal decompositions (but may fail for some gatesets). For example:
 
 .. jupyter-execute::
 
     from pytket.circuit import Circuit, OpType
-    from pytket.passes import auto_squash_pass
+    from pytket.passes import AutoSquash
 
     gates = {OpType.PhasedX, OpType.Rz, OpType.Rx, OpType.Ry}
-    custom = auto_squash_pass(gates)
+    custom = AutoSquash(gates)
 
     circ = Circuit(1).H(0).Ry(0.5, 0).Rx(-0.5, 0).Rz(1.5, 0).Ry(0.5, 0).H(0)
     custom.apply(circ)
@@ -526,9 +526,9 @@ The passes encountered so far represent elementary, self-contained transformatio
 .. jupyter-execute::
 
     from pytket import Circuit, OpType
-    from pytket.passes import auto_rebase_pass, EulerAngleReduction, SequencePass
+    from pytket.passes import AutoRebase, EulerAngleReduction, SequencePass
 
-    rebase_quil = auto_rebase_pass({OpType.CZ, OpType.Rz, OpType.Rx})
+    rebase_quil = AutoRebase({OpType.CZ, OpType.Rz, OpType.Rx})
     circ = Circuit(3)
     circ.CX(0, 1).Rx(0.3, 1).CX(2, 1).Rz(0.8, 1)
     comp = SequencePass([rebase_quil, EulerAngleReduction(OpType.Rz, OpType.Rx)])

--- a/docs/manual/manual_compiler.rst
+++ b/docs/manual/manual_compiler.rst
@@ -142,9 +142,9 @@ One of the simplest constraints to solve for is the :py:class:`~pytket.predicate
 
     print(circ.get_commands())
 
-For some gatesets, it is not even necessary to specify the CX and TK1 decompositions: there is a useful function :py:meth:`AutoRebase` which can take care of this for you. The pass returned is constructed from the gateset alone. (It relies on some known decompositions, and will raise an exception if no suitable known decompositions exist.) An example is given in the "Combinators" section below.
+For some gatesets, it is not even necessary to specify the CX and TK1 decompositions: there is a useful function :py:class:`AutoRebase` which can take care of this for you. The pass returned is constructed from the gateset alone. (It relies on some known decompositions, and will raise an exception if no suitable known decompositions exist.) An example is given in the "Combinators" section below.
 
-A similar pair of methods, :py:meth:`SquashCustom` and :py:meth:`AutoSquash`, may be used to construct a pass that squashes sequences of single-qubit gates from a given set of single-qubit gates to as short a sequence as possible. Both take a gateset as an argument. :py:meth:`SquashCustom` also takes a function for converting the parameters of a TK1 gate to the target gate set. (Internally, the compiler squashes all gates to TK1 and then applies the supplied function.) :py:meth:`AutoSquash` attempts to do the squash using known internal decompositions (but may fail for some gatesets). For example:
+A similar pair of methods, :py:meth:`SquashCustom` and :py:class:`AutoSquash`, may be used to construct a pass that squashes sequences of single-qubit gates from a given set of single-qubit gates to as short a sequence as possible. Both take a gateset as an argument. :py:meth:`SquashCustom` also takes a function for converting the parameters of a TK1 gate to the target gate set. (Internally, the compiler squashes all gates to TK1 and then applies the supplied function.) :py:class:`AutoSquash` attempts to do the squash using known internal decompositions (but may fail for some gatesets). For example:
 
 .. jupyter-execute::
 

--- a/docs/manual/manual_compiler.rst
+++ b/docs/manual/manual_compiler.rst
@@ -144,7 +144,7 @@ One of the simplest constraints to solve for is the :py:class:`~pytket.predicate
 
 For some gatesets, it is not even necessary to specify the CX and TK1 decompositions: there is a useful function :py:class:`AutoRebase` which can take care of this for you. The pass returned is constructed from the gateset alone. (It relies on some known decompositions, and will raise an exception if no suitable known decompositions exist.) An example is given in the "Combinators" section below.
 
-A similar pair of methods, :py:meth:`SquashCustom` and :py:class:`AutoSquash`, may be used to construct a pass that squashes sequences of single-qubit gates from a given set of single-qubit gates to as short a sequence as possible. Both take a gateset as an argument. :py:meth:`SquashCustom` also takes a function for converting the parameters of a TK1 gate to the target gate set. (Internally, the compiler squashes all gates to TK1 and then applies the supplied function.) :py:class:`AutoSquash` attempts to do the squash using known internal decompositions (but may fail for some gatesets). For example:
+A similar pair of methods, :py:class:`SquashCustom` and :py:class:`AutoSquash`, may be used to construct a pass that squashes sequences of single-qubit gates from a given set of single-qubit gates to as short a sequence as possible. Both take a gateset as an argument. :py:class:`SquashCustom` also takes a function for converting the parameters of a TK1 gate to the target gate set. (Internally, the compiler squashes all gates to TK1 and then applies the supplied function.) :py:class:`AutoSquash` attempts to do the squash using known internal decompositions (but may fail for some gatesets). For example:
 
 .. jupyter-execute::
 

--- a/docs/manual/manual_compiler.rst
+++ b/docs/manual/manual_compiler.rst
@@ -144,7 +144,7 @@ One of the simplest constraints to solve for is the :py:class:`~pytket.predicate
 
 For some gatesets, it is not even necessary to specify the CX and TK1 decompositions: there is a useful :py:class:`AutoRebase` pass which can take care of this for you. The pass returned is constructed from the gateset alone. (It relies on some known decompositions, and will raise an exception if no suitable known decompositions exist.) An example is given in the "Combinators" section below.
 
-The related :py:class:`SquashCustom` and :py:class:`AutoSquash` passes may be used to construct a pass that squashes sequences of single-qubit gates from a given set of single-qubit gates to as short a sequence as possible. Both take a gateset as an argument. :py:class:`SquashCustom` also takes a function for converting the parameters of a TK1 gate to the target gate set. (Internally, the compiler squashes all gates to TK1 and then applies the supplied function.) :py:class:`AutoSquash` attempts to do the squash using known internal decompositions (but may fail for some gatesets). For example:
+Similarly, the :py:class:`SquashCustom` and :py:class:`AutoSquash` passes may be used to construct a pass that squashes sequences of single-qubit gates from a given set of single-qubit gates to as short a sequence as possible. Both take a gateset as an argument. :py:class:`SquashCustom` also takes a function for converting the parameters of a TK1 gate to the target gate set. (Internally, the compiler squashes all gates to TK1 and then applies the supplied function.) :py:class:`AutoSquash` attempts to do the squash using known internal decompositions (but may fail for some gatesets). For example:
 
 .. jupyter-execute::
 

--- a/docs/manual/manual_compiler.rst
+++ b/docs/manual/manual_compiler.rst
@@ -142,9 +142,9 @@ One of the simplest constraints to solve for is the :py:class:`~pytket.predicate
 
     print(circ.get_commands())
 
-For some gatesets, it is not even necessary to specify the CX and TK1 decompositions: there is a useful function :py:class:`AutoRebase` which can take care of this for you. The pass returned is constructed from the gateset alone. (It relies on some known decompositions, and will raise an exception if no suitable known decompositions exist.) An example is given in the "Combinators" section below.
+For some gatesets, it is not even necessary to specify the CX and TK1 decompositions: there is a useful :py:class:`AutoRebase` pass which can take care of this for you. The pass returned is constructed from the gateset alone. (It relies on some known decompositions, and will raise an exception if no suitable known decompositions exist.) An example is given in the "Combinators" section below.
 
-A similar pair of methods, :py:class:`SquashCustom` and :py:class:`AutoSquash`, may be used to construct a pass that squashes sequences of single-qubit gates from a given set of single-qubit gates to as short a sequence as possible. Both take a gateset as an argument. :py:class:`SquashCustom` also takes a function for converting the parameters of a TK1 gate to the target gate set. (Internally, the compiler squashes all gates to TK1 and then applies the supplied function.) :py:class:`AutoSquash` attempts to do the squash using known internal decompositions (but may fail for some gatesets). For example:
+The related :py:class:`SquashCustom` and :py:class:`AutoSquash` passes may be used to construct a pass that squashes sequences of single-qubit gates from a given set of single-qubit gates to as short a sequence as possible. Both take a gateset as an argument. :py:class:`SquashCustom` also takes a function for converting the parameters of a TK1 gate to the target gate set. (Internally, the compiler squashes all gates to TK1 and then applies the supplied function.) :py:class:`AutoSquash` attempts to do the squash using known internal decompositions (but may fail for some gatesets). For example:
 
 .. jupyter-execute::
 

--- a/docs/manual/manual_noise.rst
+++ b/docs/manual/manual_noise.rst
@@ -363,16 +363,16 @@ An alternative class, :py:class:`UniversalFrameRandomisation`, is set with cycle
 
 Similarly as to the previous case, more shots are returning basis states in the expected state.
 
-We can use :py:meth:`auto_rebase_pass` to create a pass that can be applied to a circuit to rebase its gates to {``OpType.CX``, ``OpType.H``, ``OpType.Rz``}, the cycle gate primitives for Universal Frame Randomisation.
+We can use :py:meth:`AutoRebase` to create a pass that can be applied to a circuit to rebase its gates to {``OpType.CX``, ``OpType.H``, ``OpType.Rz``}, the cycle gate primitives for Universal Frame Randomisation.
 
 .. jupyter-execute::
 
     from pytket.circuit import PauliExpBox, Pauli, Circuit, OpType
     from pytket.transform import Transform
-    from pytket.passes import auto_rebase_pass
+    from pytket.passes import AutoRebase
     from pytket.tailoring import UniversalFrameRandomisation
 
-    rebase_ufr = auto_rebase_pass({OpType.CX, OpType.H, OpType.Rz})
+    rebase_ufr = AutoRebase({OpType.CX, OpType.H, OpType.Rz})
 
     universal_frame_randomisation = UniversalFrameRandomisation()
 

--- a/docs/manual/manual_noise.rst
+++ b/docs/manual/manual_noise.rst
@@ -363,7 +363,7 @@ An alternative class, :py:class:`UniversalFrameRandomisation`, is set with cycle
 
 Similarly as to the previous case, more shots are returning basis states in the expected state.
 
-We can use :py:meth:`AutoRebase` to create a pass that can be applied to a circuit to rebase its gates to {``OpType.CX``, ``OpType.H``, ``OpType.Rz``}, the cycle gate primitives for Universal Frame Randomisation.
+We can use :py:class:`AutoRebase` to create a pass that can be applied to a circuit to rebase its gates to {``OpType.CX``, ``OpType.H``, ``OpType.Rz``}, the cycle gate primitives for Universal Frame Randomisation.
 
 .. jupyter-execute::
 

--- a/docs/manual/manual_zx.rst
+++ b/docs/manual/manual_zx.rst
@@ -573,14 +573,14 @@ Since the :py:class:`ZXDiagram` class does not associate a :py:class:`UnitID` to
 
     from pytket import OpType
     from pytket.circuit.display import render_circuit_jupyter
-    from pytket.passes import auto_rebase_pass
+    from pytket.passes import AutoRebase
 
     c = Circuit(5)
     c.CCX(0, 1, 4)
     c.CCX(2, 4, 3)
     c.CCX(0, 1, 4)
     # Conversion is only defined for a subset of gate types - rebase as needed
-    auto_rebase_pass({ OpType.Rx, OpType.Rz, OpType.X, OpType.Z, OpType.H, OpType.CZ, OpType.CX }).apply(c)
+    AutoRebase({ OpType.Rx, OpType.Rz, OpType.X, OpType.Z, OpType.H, OpType.CZ, OpType.CX }).apply(c)
     diag, _ = circuit_to_zx(c)
 
     Rewrite.to_graphlike_form().apply(diag)


### PR DESCRIPTION
# Description

Replacing these after their deprecation in v1.29 -> https://tket.quantinuum.com/api-docs/changelog.html#id2

# Related issues

Please mention any github issues addressed by this PR.