### PR TITLE
fix: Run C.I. checks for the docs build on PRs

### DIFF
--- a/.github/workflows/check-docs-build.yml
+++ b/.github/workflows/check-docs-build.yml
@@ -9,28 +9,8 @@ on:
     - cron: '0 3 * * 6'
 
 jobs:
-
-  changes:
-    runs-on: ubuntu-22.04
-    outputs:
-      manual: ${{ steps.filter.outputs.manual }}
-    steps:
-    - uses: actions/checkout@v4
-    - uses: dorny/paths-filter@v3
-      id: filter
-      with:
-        base: ${{ github.ref }}
-        filters: |
-          manual:
-            - 'manual/**'
-            - 'manual_requirements.txt'
-            - 'manual_constraints.txt'
-            - '.github/**'
-
   check:
     name: check docs build
-    needs: changes
-    if: github.event_name == 'schedule' || needs.changes.outputs.manual == 'true'
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
# Description

Fixes the C.I. build of the docs to always run on pull requests. I think after #339 I hadn't updated the workflow correctly so the C.I. checks were skipped. This was because of the way the filtering was set up.

I have solved this for now by removing the "changes" job in C.I. that does the filtering. Let me know if there are any objections to this. I think we would want to run C.I. for most changes we make in this repository anyway. I think the only files I it would make sense to skip the checks for are README files, the licence file and `.gitignore`

Alternatively I could update the filtering to check for updates to the new files.

This PR should be merged before #370  to be on the safe side.

# Related issues
Fixes #368 