### PR TITLE
fix: update broken ZX rewrite table

### DIFF
--- a/docs/manual/manual_zx.md
+++ b/docs/manual/manual_zx.md
@@ -502,7 +502,6 @@ Composite sequences
                                       `Rewrite.reduce_graphlike_form()`,
                                       `Rewrite.to_MBQC_diag()`
 =================================== ===========================================
-```
 
 % Current implementations may not track global scalar; semantics is only preserved up to scalar; warning if attempting to use for scalar diagram evaluation
 

--- a/docs/manual/manual_zx.md
+++ b/docs/manual/manual_zx.md
@@ -475,14 +475,33 @@ Because of the focus on strategies using graphlike diagrams, many of the rewrite
 The rewrite passes can be broken down into a few categories depending on the form of the diagrams expected and the function of the passes. Full descriptions of each pass are given in the API reference.
 
 
-
-|  Rewrite Category                  | Available Rewrites                                                                                                                                                                            |
-|------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Decompositions into generating set | `Rewrite.decompose_boxes()`, `Rewrite.basic_wires()`,     `Rewrite.rebase_to_zx()`,    `Rewrite.rebase_to_mbqc()`                                                                             |
-| Rewriting into graphlike form      | `Rewrite.red_to_green()`,        `Rewrite.spider_fusion()`,       `Rewrite.self_loop_removal()`,   `Rewrite.parallel_h_removal()`,  `Rewrite.separate_boundaries()`, `Rewrite.io_extension()` |
-| Reduction within graphlike form    | `Rewrite.remove_interior_cliffords()` `Rewrite.remove_interior_paulis()` `Rewrite.gadgetise_interior_paulis()` `Rewrite.merge_gadgets()` `Rewrite.extend_at_boundary_paulis()`                |
-| MBQC                               | `Rewrite.extend_for_PX_outputs()`, `Rewrite.internalise_gadgets()`                                                                                                                            |
-| Composite sequences                | `Rewrite.to_graphlike_form()`,     `Rewrite.reduce_graphlike_form()`, `Rewrite.to_MBQC_diag()`                                                                                                |
+=================================== ===========================================
+Decompositions into generating sets
+                                      `Rewrite.decompose_boxes()`,
+                                      `Rewrite.basic_wires()`,
+                                      `Rewrite.rebase_to_zx()`,
+                                      `Rewrite.rebase_to_mbqc()`
+Rewriting into graphlike form
+                                      `Rewrite.red_to_green()`,
+                                      `Rewrite.spider_fusion()`,
+                                      `Rewrite.self_loop_removal()`,
+                                      `Rewrite.parallel_h_removal()`,
+                                      `Rewrite.separate_boundaries()`,
+                                      `Rewrite.io_extension()`
+Reduction within graphlike form
+                                      `Rewrite.remove_interior_cliffords()`,
+                                      `Rewrite.remove_interior_paulis()`,
+                                      `Rewrite.gadgetise_interior_paulis()`,
+                                      `Rewrite.merge_gadgets()`,
+                                      `Rewrite.extend_at_boundary_paulis()`
+MBQC
+                                      `Rewrite.extend_for_PX_outputs()`,
+                                      `Rewrite.internalise_gadgets()`
+Composite sequences
+                                      `Rewrite.to_graphlike_form()`,
+                                      `Rewrite.reduce_graphlike_form()`,
+                                      `Rewrite.to_MBQC_diag()`
+=================================== ===========================================
 
 % Current implementations may not track global scalar; semantics is only preserved up to scalar; warning if attempting to use for scalar diagram evaluation
 

--- a/docs/manual/manual_zx.md
+++ b/docs/manual/manual_zx.md
@@ -475,33 +475,14 @@ Because of the focus on strategies using graphlike diagrams, many of the rewrite
 The rewrite passes can be broken down into a few categories depending on the form of the diagrams expected and the function of the passes. Full descriptions of each pass are given in the API reference.
 
 
-=================================== ===========================================
-Decompositions into generating sets
-                                      `Rewrite.decompose_boxes()`,
-                                      `Rewrite.basic_wires()`,
-                                      `Rewrite.rebase_to_zx()`,
-                                      `Rewrite.rebase_to_mbqc()`
-Rewriting into graphlike form
-                                      `Rewrite.red_to_green()`,
-                                      `Rewrite.spider_fusion()`,
-                                      `Rewrite.self_loop_removal()`,
-                                      `Rewrite.parallel_h_removal()`,
-                                      `Rewrite.separate_boundaries()`,
-                                      `Rewrite.io_extension()`
-Reduction within graphlike form
-                                      `Rewrite.remove_interior_cliffords()`,
-                                      `Rewrite.remove_interior_paulis()`,
-                                      `Rewrite.gadgetise_interior_paulis()`,
-                                      `Rewrite.merge_gadgets()`,
-                                      `Rewrite.extend_at_boundary_paulis()`
-MBQC
-                                      `Rewrite.extend_for_PX_outputs()`,
-                                      `Rewrite.internalise_gadgets()`
-Composite sequences
-                                      `Rewrite.to_graphlike_form()`,
-                                      `Rewrite.reduce_graphlike_form()`,
-                                      `Rewrite.to_MBQC_diag()`
-=================================== ===========================================
+
+|  Rewrite Category                  | Available Rewrites                                                                                                                                                                            |
+|------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Decompositions into generating set | `Rewrite.decompose_boxes()`, `Rewrite.basic_wires()`,     `Rewrite.rebase_to_zx()`,    `Rewrite.rebase_to_mbqc()`                                                                             |
+| Rewriting into graphlike form      | `Rewrite.red_to_green()`,        `Rewrite.spider_fusion()`,       `Rewrite.self_loop_removal()`,   `Rewrite.parallel_h_removal()`,  `Rewrite.separate_boundaries()`, `Rewrite.io_extension()` |
+| Reduction within graphlike form    | `Rewrite.remove_interior_cliffords()` `Rewrite.remove_interior_paulis()` `Rewrite.gadgetise_interior_paulis()` `Rewrite.merge_gadgets()` `Rewrite.extend_at_boundary_paulis()`                |
+| MBQC                               | `Rewrite.extend_for_PX_outputs()`, `Rewrite.internalise_gadgets()`                                                                                                                            |
+| Composite sequences                | `Rewrite.to_graphlike_form()`,     `Rewrite.reduce_graphlike_form()`, `Rewrite.to_MBQC_diag()`                                                                                                |
 
 % Current implementations may not track global scalar; semantics is only preserved up to scalar; warning if attempting to use for scalar diagram evaluation
 

--- a/docs/manual/manual_zx.md
+++ b/docs/manual/manual_zx.md
@@ -474,34 +474,35 @@ Because of the focus on strategies using graphlike diagrams, many of the rewrite
 
 The rewrite passes can be broken down into a few categories depending on the form of the diagrams expected and the function of the passes. Full descriptions of each pass are given in the API reference.
 
-
+```{eval-rst}
 =================================== ===========================================
 Decompositions into generating sets
-                                      `Rewrite.decompose_boxes()`,
-                                      `Rewrite.basic_wires()`,
-                                      `Rewrite.rebase_to_zx()`,
-                                      `Rewrite.rebase_to_mbqc()`
+                                      ``Rewrite.decompose_boxes()``,
+                                      ``Rewrite.basic_wires()``,
+                                      ``Rewrite.rebase_to_zx()``,
+                                      ``Rewrite.rebase_to_mbqc()``
 Rewriting into graphlike form
-                                      `Rewrite.red_to_green()`,
-                                      `Rewrite.spider_fusion()`,
-                                      `Rewrite.self_loop_removal()`,
-                                      `Rewrite.parallel_h_removal()`,
-                                      `Rewrite.separate_boundaries()`,
-                                      `Rewrite.io_extension()`
+                                      ``Rewrite.red_to_green()``,
+                                      ``Rewrite.spider_fusion()``,
+                                      ``Rewrite.self_loop_removal()``,
+                                      ``Rewrite.parallel_h_removal()``,
+                                      ``Rewrite.separate_boundaries()``,
+                                      ``Rewrite.io_extension()``
 Reduction within graphlike form
-                                      `Rewrite.remove_interior_cliffords()`,
-                                      `Rewrite.remove_interior_paulis()`,
-                                      `Rewrite.gadgetise_interior_paulis()`,
-                                      `Rewrite.merge_gadgets()`,
-                                      `Rewrite.extend_at_boundary_paulis()`
+                                      ``Rewrite.remove_interior_cliffords()``,
+                                      ``Rewrite.remove_interior_paulis()``,
+                                      ``Rewrite.gadgetise_interior_paulis()``,
+                                      ``Rewrite.merge_gadgets()``,
+                                      ``Rewrite.extend_at_boundary_paulis()``
 MBQC
-                                      `Rewrite.extend_for_PX_outputs()`,
-                                      `Rewrite.internalise_gadgets()`
+                                      ``Rewrite.extend_for_PX_outputs()``,
+                                      ``Rewrite.internalise_gadgets()``
 Composite sequences
-                                      `Rewrite.to_graphlike_form()`,
-                                      `Rewrite.reduce_graphlike_form()`,
-                                      `Rewrite.to_MBQC_diag()`
+                                      ``Rewrite.to_graphlike_form()``,
+                                      ``Rewrite.reduce_graphlike_form()``,
+                                      ``Rewrite.to_MBQC_diag()``
 =================================== ===========================================
+```
 
 % Current implementations may not track global scalar; semantics is only preserved up to scalar; warning if attempting to use for scalar diagram evaluation
 

--- a/docs/manual/manual_zx.md
+++ b/docs/manual/manual_zx.md
@@ -476,6 +476,9 @@ The rewrite passes can be broken down into a few categories depending on the for
 
 ```{eval-rst}
 =================================== ===========================================
+**Rewrite Category**                  **Available Rewrites**
+
+
 Decompositions into generating sets
                                       ``Rewrite.decompose_boxes()``,
                                       ``Rewrite.basic_wires()``,


### PR DESCRIPTION
# Description

ZX table was invalidated by bad syntax. Likely introduced in [#366 ](https://github.com/CQCL/pytket-docs/pull/370)

Before
<img width="775" alt="Screenshot 2024-10-14 at 23 31 47" src="https://github.com/user-attachments/assets/4a3eb12e-5ab8-4851-b458-08dff9bb6c6b">

After


<img width="769" alt="Screenshot 2024-10-14 at 23 32 10" src="https://github.com/user-attachments/assets/219bc660-9d68-4cde-93c6-9402c978d6b0">
