### PR TITLE
ci: update github org name (`CQCL-DEV` -> `quantinuum-dev`)

### DIFF
--- a/.github/workflows/issue_to_project.yml
+++ b/.github/workflows/issue_to_project.yml
@@ -12,5 +12,5 @@ jobs:
     steps:
       - uses: actions/add-to-project@v1.0.2
         with:
-          project-url: https://github.com/orgs/CQCL-DEV/projects/19
+          project-url: https://github.com/orgs/quantinuum-dev/projects/19
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
# Description


Adding an issue to the gh-project board was failing due to the name of the org being outdated.
https://github.com/CQCL/pytket-docs/actions/runs/12414509338



# Related issues

Please mention any github issues addressed by this PR.