### PR TITLE
fix: run c.i. checks when PRs are merged

### DIFF
--- a/.github/workflows/check-docs-build.yml
+++ b/.github/workflows/check-docs-build.yml
@@ -1,9 +1,11 @@
 name: check docs build
 
 on:
+  push:
+    branches: [ "main" ]
   pull_request:
-    branches:
-      - main
+    branches: [ "main" ]
+      
   schedule:
     # 03:00 every Saturday morning
     - cron: '0 3 * * 6'


### PR DESCRIPTION
# Description

Update the workflow to run checks when PRs are merged in additon to running the tests prior to merging.
